### PR TITLE
fix: link to Examples in docs/v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Full documentation is available at [neko.m1k1o.net](https://neko.m1k1o.net/). Ke
 - [Migration from V2](https://neko.m1k1o.net/docs/v3/migration-from-v2)
 - [Getting Started](https://neko.m1k1o.net/docs/v3/quick-start)
 - [Installation](https://neko.m1k1o.net/docs/v3/installation)
-- [Examples](https://neko.m1k1o.net/v3/installation/examples)
+- [Examples](https://neko.m1k1o.net/docs/v3/installation/examples)
 - [Configuration](https://neko.m1k1o.net/docs/v3/configuration)
 - [Frequently Asked Questions](https://neko.m1k1o.net/docs/v3/faq)
 - [Troubleshooting](https://neko.m1k1o.net/docs/v3/troubleshooting)


### PR DESCRIPTION
Previous link of /v3/installation/examples was broken.